### PR TITLE
fix steamcmd install dir

### DIFF
--- a/linux.Dockerfile
+++ b/linux.Dockerfile
@@ -5,7 +5,7 @@ FROM lacledeslan/steamcmd:linux as svencoop-builder
 COPY ./build-cache /output
 
 # Download Sven Co-Op Dedicated Server
-RUN /app/steamcmd.sh +login anonymous +force_install_dir /output +app_update 276060 validate +quit;
+RUN /app/steamcmd.sh +force_install_dir /output +login anonymous +app_update 276060 validate +quit;
 
 #=======================================================================
 FROM debian:bullseye-slim


### PR DESCRIPTION
Change on SteamCMD requires force_install_dir before login

Also see warning on here: 
https://developer.valvesoftware.com/wiki/SteamCMD#ERROR.21_Failed_to_install_app_.22xxxxxx.22_.28No_subscription.29